### PR TITLE
Improve tab locking functionality

### DIFF
--- a/header.go
+++ b/header.go
@@ -13,9 +13,6 @@ type header struct {
 	// termReady is control terminal is ready or not, it responsible for the terminal size
 	termReady bool
 
-	// lockTabs is control the tabs (headers) are locked or not
-	lockTabs bool
-
 	// currentTab is hold the current tab index
 	currentTab int
 
@@ -244,12 +241,24 @@ func (h *header) SetCurrentTab(tab int) {
 
 // SetLockTabs sets the lock tabs status.
 func (h *header) SetLockTabs(lock bool) {
-	h.lockTabs = lock
+	if lock {
+		for _, header := range h.headers {
+			h.LockTab(header.key)
+		}
+	} else {
+		h.lockedTabs = make(map[string]bool)
+	}
+	h.updater.Update()
 }
 
 // GetLockTabs returns the lock tabs status.
 func (h *header) GetLockTabs() bool {
-	return h.lockTabs
+	for _, header := range h.headers {
+		if !h.IsTabLocked(header.key) {
+			return false
+		}
+	}
+	return true
 }
 
 // GetCurrentTab returns the current tab index.

--- a/header.go
+++ b/header.go
@@ -1,11 +1,11 @@
 package skeleton
 
 import (
-	"github.com/charmbracelet/bubbles/key"
+	"strings"
+
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"strings"
 )
 
 // header is a helper for rendering the header of the terminal.
@@ -35,6 +35,9 @@ type header struct {
 	titleLength int
 
 	updater *Updater
+
+	// lockedTabs holds the keys of individually locked tabs
+	lockedTabs map[string]bool
 }
 
 // newHeader returns a new header.
@@ -45,6 +48,7 @@ func newHeader() *header {
 		currentTab: 0,
 		keyMap:     newKeyMap(),
 		updater:    NewUpdater(),
+		lockedTabs: make(map[string]bool),
 	}
 }
 
@@ -119,17 +123,6 @@ func (h *header) Update(msg tea.Msg) (*header, tea.Cmd) {
 		h.calculateTitleLength()
 
 		cmds = append(cmds, h.calculateTitleLength())
-	case tea.KeyMsg:
-		switch {
-		case key.Matches(msg, h.keyMap.SwitchTabLeft):
-			if !h.GetLockTabs() {
-				h.currentTab = max(h.currentTab-1, 0)
-			}
-		case key.Matches(msg, h.keyMap.SwitchTabRight):
-			if !h.GetLockTabs() {
-				h.currentTab = min(h.currentTab+1, len(h.headers)-1)
-			}
-		}
 	}
 
 	return h, tea.Batch(cmds...)
@@ -183,7 +176,7 @@ func (h *header) View() string {
 		if i == h.currentTab {
 			renderedTitles = append(renderedTitles, h.properties.titleStyleActive.Render(hdr.title))
 		} else {
-			if h.GetLockTabs() {
+			if h.GetLockTabs() || h.IsTabLocked(hdr.key) {
 				renderedTitles = append(renderedTitles, h.properties.titleStyleDisabled.Render(hdr.title))
 			} else {
 				renderedTitles = append(renderedTitles, h.properties.titleStyleInactive.Render(hdr.title))
@@ -293,5 +286,22 @@ func (h *header) DeleteCommonHeader(key string) {
 		}
 	}
 	h.calculateTitleLength()
+	h.updater.Update()
+}
+
+// IsTabLocked checks if a specific tab is locked
+func (h *header) IsTabLocked(key string) bool {
+	return h.lockedTabs[key]
+}
+
+// LockTab locks a specific tab by its key
+func (h *header) LockTab(key string) {
+	h.lockedTabs[key] = true
+	h.updater.Update()
+}
+
+// UnlockTab unlocks a specific tab by its key
+func (h *header) UnlockTab(key string) {
+	delete(h.lockedTabs, key)
 	h.updater.Update()
 }

--- a/skeleton.go
+++ b/skeleton.go
@@ -20,9 +20,6 @@ type Skeleton struct {
 	// termSizeNotEnoughToHandleWidgets is control terminal size is enough to handle widgets
 	termSizeNotEnoughToHandleWidgets bool
 
-	// lockTabs is control the tabs (headers) are locked or not
-	lockTabs bool
-
 	// currentTab is hold the current tab index
 	currentTab int
 
@@ -177,8 +174,9 @@ func (s *Skeleton) SetWidgetRightPadding(padding int) *Skeleton {
 
 // LockTabs locks the tabs (headers). It prevents switching tabs. It is useful when you want to prevent switching tabs.
 func (s *Skeleton) LockTabs() *Skeleton {
-	s.header.SetLockTabs(true)
-	s.lockTabs = true
+	for _, header := range s.header.headers {
+		s.LockTab(header.key)
+	}
 	s.updater.Update()
 	return s
 }
@@ -186,7 +184,6 @@ func (s *Skeleton) LockTabs() *Skeleton {
 // UnlockTabs unlocks all tabs (both general and individual locks)
 func (s *Skeleton) UnlockTabs() *Skeleton {
 	s.header.SetLockTabs(false)
-	s.lockTabs = false
 
 	// Clear all individual tab locks
 	for _, header := range s.header.headers {
@@ -199,7 +196,7 @@ func (s *Skeleton) UnlockTabs() *Skeleton {
 
 // IsTabsLocked returns the tabs (headers) are locked or not.
 func (s *Skeleton) IsTabsLocked() bool {
-	return s.lockTabs
+	return s.header.GetLockTabs()
 }
 
 // AddPageMsg adds a new page to the Skeleton.


### PR DESCRIPTION
# Tab Management System Improvements

## Changes
### New Methods
- Added `switchPage()` method to handle tab navigation with lock awareness
- Added `LockTab(key string)` to lock individual tabs by their key
- Added `UnlockTab(key string)` to unlock individual tabs by their key
- Added `IsTabLocked(key string)` to check if a specific tab is locked
- Added `LockTabsToTheLeft()` to lock all tabs to the left of current tab
- Added `LockTabsToTheRight()` to lock all tabs to the right of current tab
- Added `UnlockTabs()` to clear all tab locks (both general and individual)

### Improvements
- Implemented smart tab navigation that skips locked tabs
- Added boundary checks to prevent unnecessary operations when at edge tabs
- Improved tab lock state management in header component
- Added support for both general tab locking and individual tab locking

## Details
### Tab Navigation
- When navigating left/right, the system now automatically skips locked tabs
- Navigation stops if all tabs in the direction are locked

### Lock Management
- `LockTab(key)`: Locks a specific tab by its key
- `UnlockTab(key)`: Unlocks a specific tab by its key
- `IsTabLocked(key)`: Returns true if the specified tab is locked
- `LockTabsToTheLeft()`: Locks all tabs from index 0 to current tab (exclusive)
- `LockTabsToTheRight()`: Locks all tabs from current tab + 1 to the end
- `UnlockTabs()`: Clears all types of locks (both general and individual)

## Example Usage
```go
s.AddPage("first", "First Tab", firstModel)
s.AddPage("second", "Second Tab", secondModel)
s.AddPage("third", "Third Tab", thirdModel)
s.AddPage("fourth", "Fourth Tab", fourthModel)
s.AddPage("fifth", "Fifth Tab", fifthModel)

// Individual tab locking
s.LockTab("second")      // Locks second tab
s.UnlockTab("second")    // Unlocks second tab
s.IsTabLocked("second")  // Checks if second tab is locked

// Bulk tab locking
s.LockTabsToTheLeft()    // Locks all tabs to the left of current tab
s.LockTabsToTheRight()   // Locks all tabs to the right of current tab
s.UnlockTabs()          // Unlocks all tabs
```

## Testing
- Tested individual tab locking/unlocking
- Tested bulk tab locking (left/right)
- Verified tab navigation with locked tabs
- Confirmed that `UnlockTabs()` properly clears all locks
- Tested boundary conditions (first/last tab)