### PR TITLE
Fix incorrect viewport height calculation when not using widgets

### DIFF
--- a/skeleton.go
+++ b/skeleton.go
@@ -461,12 +461,9 @@ func (s *Skeleton) View() string {
 
 	// Calculate available height for body
 	headerHeight := lipgloss.Height(s.header.View())
-	widgetHeight := 0
-	if len(s.widget.widgets) > 0 {
-		widgetHeight = lipgloss.Height(s.widget.View())
-	}
+	footerHeight := lipgloss.Height(s.widget.View())
 
-	bodyHeight := s.viewport.Height - headerHeight - widgetHeight
+	bodyHeight := s.viewport.Height - headerHeight - footerHeight
 
 	// Style for the body content
 	base := lipgloss.NewStyle().


### PR DESCRIPTION
I noticed incorrect viewport height when there are no widgets added.

<details>
<summary>before</summary>

<img width="696" height="279" alt="image" src="https://github.com/user-attachments/assets/9e05a47a-456b-4d84-8eef-048998ef96a9" />

</details>

<details>
<summary>after</summary>

<img width="696" height="279" alt="image" src="https://github.com/user-attachments/assets/2d3fe3ac-b754-4609-9ffb-854e2d301d88" />

</details>

