### PR TITLE
Add methods to get content width and height

### DIFF
--- a/viewport.go
+++ b/viewport.go
@@ -1,8 +1,10 @@
 package skeleton
 
 import (
-	"github.com/charmbracelet/bubbles/viewport"
 	"sync"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	"github.com/charmbracelet/lipgloss"
 )
 
 // --------------------------------------------
@@ -44,4 +46,16 @@ func (s *Skeleton) GetTerminalWidth() int {
 // GetTerminalHeight returns the height of the terminal.
 func (s *Skeleton) GetTerminalHeight() int {
 	return vp.Height
+}
+
+// GetContentWidth returns the available width for content (terminal width minus borders).
+func (s *Skeleton) GetContentWidth() int {
+	return vp.Width - 2
+}
+
+// GetContentHeight returns the available height for content (terminal height minus header and widgets).
+func (s *Skeleton) GetContentHeight() int {
+	headerHeight := lipgloss.Height(s.header.View())
+	footerHeight := lipgloss.Height(s.widget.View())
+	return vp.Height - headerHeight - footerHeight
 }


### PR DESCRIPTION
The GetTerminalWidth and GetTerminalHeight methods are useful but don't give enough information to correctly format the content in the content area. Adding functions which calculate the available height/width will allow more flexibility when fitting the content area.